### PR TITLE
Added warning option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Options supported:
 * `text` - CSS document or fragment to validate. Only CSS-content is allowed
 * `profile` - the CSS profile used for the validation: `css1, css2, css21, css3` [default: 'css3']
 * `usermedium` - the [medium](http://www.w3.org/TR/CSS2/media.html) used for the validation: `screen, print, ...` [default: 'all', which is suitable for all devices]
+* `warning` - The warning level, "no" for no warnings, 0 for less warnings, 1or 2 for more warnings [default: 2] 
 
 
 The  [optional] callback argument gets 2 arguments:

--- a/lib/css-validator.js
+++ b/lib/css-validator.js
@@ -11,7 +11,8 @@ var config = {
   defaultParams: {
     profile: 'css3',
     usermedium: 'all',
-    output: 'soap12'
+    output: 'soap12',
+    warning: 2
   }
 };
 
@@ -52,6 +53,7 @@ function validate(params, callback) {
   query.profile = params.profile || config.defaultParams.profile;
   query.usermedium = params.usermedium || config.defaultParams.usermedium;
   query.output = config.defaultParams.output;
+  query.warning = params.warning || config.defaultParams.warning;
 
   if(hasUri) {
     query.uri = params.url || params.uri;


### PR DESCRIPTION
I suggest to add warning option, according to
http://jigsaw.w3.org/css-validator/manual.html#api

My idea is to shrink the JSON an user recieves. After that I propose to create an options for gulp-w3c-css, using which we well be able to see css errors in the console, instead of in the JSON file
